### PR TITLE
Make the QML example a bit more idiomatic

### DIFF
--- a/Qt5/OnlyQML/Counter/counter.qml
+++ b/Qt5/OnlyQML/Counter/counter.qml
@@ -10,19 +10,18 @@ Window {
     visible: true
 
     property int counter: 0
+
     RowLayout {
-        id: layout
         anchors.fill: parent
         spacing: 6
+
         Label {
-            id: theCount
-            text: String(counterWindow.counter)
+            text: counterWindow.counter
         }
 
         Button {
-            id: theButton
             text: "Increment"
-            onClicked: theCount.text = String(++counterWindow.counter)
+            onClicked: ++counterWindow.counter
         }
     }
 }


### PR DESCRIPTION
* Conversion from int to string happens implicitly
* Rely on the binding to re-evaluate instead of assigning to label.text