### PR TITLE
Add Clojurescript / Reagent Implementation

### DIFF
--- a/site/src/containers/Implementations.js
+++ b/site/src/containers/Implementations.js
@@ -283,4 +283,12 @@ const implementations = [
     link: 'https://github.com/tdryer/7guis-fltk-rs#7guis-fltk-rs',
     src: 'https://github.com/tdryer/7guis-fltk-rs',
   },
+  {
+    title: 'Clojurescript/Reagent',
+    technologies: ['Clojurescript', 'Reagent'],
+    author: 'Ar Nazeh',
+    authorLink: 'https://github.com/Nazeh',
+    link: 'https://7guis-cljs.nzh.io/',
+    src: 'https://github.com/Nazeh/7guis-cljs',
+  },
 ]


### PR DESCRIPTION
Add [Clojurescript / Reagent Implementation][0] to the implementations page.

[0]: https://7guis-cljs.nzh.io/